### PR TITLE
Exception.php for string-based database errors

### DIFF
--- a/php/Exception/Exception.php
+++ b/php/Exception/Exception.php
@@ -9,7 +9,7 @@ class jqGrid_Exception extends Exception
     public function __construct($message, $data = null, $code = 0)
     {
         $this->data = $data;
-        return parent::__construct($message, $code);
+        return parent::__construct($message, intval($code), NULL);
     }
 
     public function getData()


### PR DESCRIPTION
MySQL reports errors with codes of the form HY0000, but PHP only allows integer values for $code when constructing Exceptions.
