### PR TITLE
Although first column is not 'db' is used as primary key.

### DIFF
--- a/examples/grids/jqCols.php
+++ b/examples/grids/jqCols.php
@@ -73,7 +73,7 @@ class jqCols extends jqGrid
 
             #This column is processed MANUALLY in PHP code
             'diff_price' => array('label' => 'Diff',
-                'manual' => true,
+                'db' => false,
                 'width' => 12,
                 'search' => false,
                 'sortable' => false,

--- a/examples/grids/jqOperUpload.php
+++ b/examples/grids/jqOperUpload.php
@@ -21,7 +21,7 @@ class jqOperUpload extends jqGrid
 
             'image' => array('label' => 'Image',
                 'width' => 14,
-                'manual' => true, //manually create images in PHP
+                'db' => false, //manually create images in PHP
                 //you can use JS formatter instead
                 'encode' => false,
                 'sortable' => false,
@@ -52,7 +52,7 @@ class jqOperUpload extends jqGrid
 
             #Hidden column for uploading
             'upload' => array('label' => 'Upload image',
-                'manual' => true,
+                'db' => false,
                 'hidden' => true,
                 'editable' => true,
                 'edittype' => 'file',

--- a/examples/templates/jqCols.php
+++ b/examples/templates/jqCols.php
@@ -3,21 +3,21 @@
 </script>
 
 <div id="descr">
-    This exmaple introduce new column options: <b>db</b>, <b>db_agg</b>, <b>manual</b> and <b>unset</b>.<br><br>
+    This exmaple introduce new column options: <b>db</b>, <b>db_agg</b> and <b>unset</b>.<br><br>
 
     <b>db</b>- column representation in database queries.<br>
     <b>db_agg</b> - calculates aggregate function among the whole data set (all pages, not one).<br>
-    <b>manual</b> - column is ignored by database. You should fill it manually within <b>parseRow</b> function.<br>
+    <b>db=&gt;false</b> - column is ignored by database. You should fill it manually within <b>parseRow</b> function.<br>
     <b>unset</b> - column is ignored by client script. It is only visible in PHP.<br><br>
 </div>
 
 <div id="descr_rus">
-    Этот пример показывает новые опции колонок: <b>db</b>, <b>db_agg</b>, <b>manual</b> и <b>unset</b>.<br><br>
+    Этот пример показывает новые опции колонок: <b>db</b>, <b>db_agg</b> и <b>unset</b>.<br><br>
 
     <b>db</b> - имя колонки в SQL запросе<br><br>
     <b>db_agg</b> - выполнение aggregate функции (count, sum и т.п.) - часто используется для вывода дополнительного
     ряда "Итого:"<br><br>
-    <b>manual</b> - колонка игнорируется при составлении запросов к БД. Вы должны явно определить её значение в функции
+    <b>db=&gt;false</b> - колонка игнорируется при составлении запросов к БД. Вы должны явно определить её значение в функции
     <b>parseRow</b>.<br><br>
     <b>unset</b> - колонка игнорируется клиентской частью. Она будет отсутствовать в colModel на стороне клиента. Её
     видно только на стороне сервера.<br><br>

--- a/php/Adapter/CSV.php
+++ b/php/Adapter/CSV.php
@@ -40,7 +40,7 @@ abstract class jqGrid_Adapter_CSV extends jqGrid
         #Preserve column order!
         foreach($this->cols as $k => $c)
         {
-            if(!$c['manual'] and $k != $this->primary_key[0])
+            if($c['db'] && $k != $this->primary_key[0])
             {
                 $new_row[$k] = isset($ins[$k]) ? $ins[$k] : null;
             }


### PR DESCRIPTION
It is also proposed to use `'db' => false` to indicate that a column is not from database (equivalent to `'manual' => true`, that for compatibility continues to operate)
