### PR TITLE
After jqGrid v5.0 the validation exceptions are not displayed.

### DIFF
--- a/client/jqgrid-ext.js
+++ b/client/jqgrid-ext.js
@@ -57,7 +57,18 @@ $.jgrid.ext =
 				$(this).attr('name', $(this).data('name'));
 			});
 		}, 200);
-	}
+	},
+    //---------------
+    // Used by form edit error handler
+    //---------------
+    afterSubmit: function(data) {
+        var json = $.jgrid.parse(data.responseText);
+        if(typeof(json.error_msg) != 'undefined') {
+            return [false, json.error_msg, 0];
+        }
+        var new_id = json.new_id || 0;
+        return [true, null, new_id];
+    }
 };
 
 //---------------
@@ -110,45 +121,6 @@ $.extend($.fn.fmatter,
 		
 		return $.jgrid.format('<a href="{0}" class="{1}" target="{2}">{3}</a>', href, opt['class'], opt['target'], cellvalue);
 	}
-});
-
-//---------------
-// Form edit error handler
-//---------------
-
-$.extend($.jgrid.edit,
-{
-	afterSubmit: function(data)
-	{
-		var json = $.jgrid.parse(data.responseText);
-		var new_id = json.new_id || 0;
-		
-		if(typeof(json.error_msg) != 'undefined')
-		{
-			return [false, json.error_msg, new_id];
-		}
-		
-		return [true, null, new_id];
-	},
-	
-	recreateForm : true
-});
-
-$.extend($.jgrid.del,
-{
-	afterSubmit: function(data)
-	{
-		var json = $.jgrid.parse(data.responseText);
-
-		if(typeof(json.error_msg) != 'undefined')
-		{
-			return [false, json.error_msg, 0];
-		}
-
-		return [true, null, 0];
-	},
-
-	recreateForm : true
 });
 
 //---------------

--- a/php/Utils/Utils.php
+++ b/php/Utils/Utils.php
@@ -30,6 +30,10 @@ class jqGrid_Utils
                 $a = str_replace(",", ".", strval($a));
             }
 
+            if (is_string($a) && substr($a, 0, 4) === '<?js' && substr($a, -2, 2) === '?>')
+            {
+                return substr($a, 5, -2);
+            }
             return '"' . str_replace($jsonReplaces[0], $jsonReplaces[1], $a) . '"';
         }
 

--- a/php/jqGrid.php
+++ b/php/jqGrid.php
@@ -86,6 +86,21 @@ abstract class jqGrid
             'refresh' => true,
             'search' => false,
             'view' => false,
+            //---------------
+            // Form edit error handler
+            //---------------
+            'prmAdd' => array(
+                'recreateForm'  => true,
+                'afterSubmit' => "<?js \$.jgrid.ext.afterSubmit ?>"
+            ),
+            'prmEdit' => array(
+                'recreateForm'  => true,
+                'afterSubmit' => "<?js \$.jgrid.ext.afterSubmit ?>"
+            ),
+            'prmDel' => array(
+                'recreateForm'  => true,
+                'afterSubmit' => "<?js \$.jgrid.ext.afterSubmit ?>"
+            ),
         ),
 
         'options' => array(
@@ -1230,17 +1245,18 @@ $grid.jqGrid($.extend(' . jqGrid_Utils::jsonEncode($data['options']) . ', typeof
             #Respect the argument order
             foreach($nav_special as $k)
             {
+                $code .= ",\n /*{$k}:*/ ";
                 if(isset($data['nav'][$k]))
                 {
-                    $code .= ', ' . jqGrid_Utils::jsonEncode($data['nav'][$k]);
+                    $code .= jqGrid_Utils::jsonEncode($data['nav'][$k]);
                 }
                 else
                 {
-                    $code .= ', null';
+                    $code .= 'null';
                 }
             }
 
-            $code .= ");\n";
+            $code .= "\n);\n";
 
             #Excel button
             if(isset($data['nav']['excel']) and $data['nav']['excel'])


### PR DESCRIPTION
This is because on jqGrid v5.0 the `$.jgrid.edit` and `$.jgrid.del` no longer exist.

NOTE: A new js wrapper code is added to allow js code assign at the time of defining properties on jqGrid class:

```
    'property_name' => '<?js the_js_code ?>',
```
