### PR TITLE
After jQuery 1.9 export excel fails.

### DIFF
--- a/client/jqgrid-ext.js
+++ b/client/jqgrid-ext.js
@@ -331,28 +331,35 @@ $.jgrid.extend(
 	{
 		return this.each(function(type)
 		{
-			$grid = $(this);
+			var $grid = $(this);
 			
 			var url  = $grid.jqGrid('getGridParam', 'url');
 			var postData = $grid.jqGrid('getGridParam', 'postData');
 			
 			var $frame = $('<iframe src="' + url + '&' + $.param($.extend(null, postData, {'_out' : 'export'}, data)) + '" style="display:none;"></iframe>');
 			
-			$frame.load(function()
+			var _inter = null;
+			var _successFn = function()
 			{
+				window.clearInterval(_inter);
+				_inter = null;
 				if($.isFunction(success))
 				{
 					success.call($grid);
 				}
 				
 				$grid.jqGrid('extLoading', false);
-			});
-			
-			if(!$.browser.msie && !$.browser.opera)
-			{
-				$grid.jqGrid('extLoading', true);
-			}
-			
+			};
+
+			$frame.load(_successFn); // FF, Chrome, ...
+			_inter = window.setInterval( function() { // IE-Edge, Safari
+				if ($('head', $frame.contents())) {
+					_successFn();
+				}
+			}, 500);
+
+			$grid.jqGrid('extLoading', true);
+
 			$('html').append($frame);
 		});
 	},


### PR DESCRIPTION
This is due to property `jQuery.browser` was removed in jQuery 1.9.

But there is another problem: until now when is specified the `success` function of click "export to excel" the function is never called using IE/Edge and Safari.

Both problems are fixed by this patch.
